### PR TITLE
feature: hooks

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION=0.0.1-alpha.22
+VERSION=0.0.1-alpha.23

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempojs",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "something",
   "private": true,
   "workspaces": [
@@ -26,9 +26,9 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@tempojs/client": "^0.0.1-alpha.22",
-    "@tempojs/common": "^0.0.1-alpha.22",
-    "@tempojs/server": "^0.0.1-alpha.22",
+    "@tempojs/client": "^0.0.1-alpha.23",
+    "@tempojs/common": "^0.0.1-alpha.23",
+    "@tempojs/server": "^0.0.1-alpha.23",
     "bebop": "^2.7.0"
   }
 }

--- a/typescript/packages/cf-router/package.json
+++ b/typescript/packages/cf-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/cloudflare-worker-router",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -19,7 +19,7 @@
   "author": "andrew",
   "license": "",
   "dependencies": {
-    "@tempojs/server": "^0.0.1-alpha.22"
+    "@tempojs/server": "^0.0.1-alpha.23"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20221111.1"

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/client",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "xrpc client",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -16,6 +16,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@tempojs/common": "^0.0.1-alpha.22"
+    "@tempojs/common": "^0.0.1-alpha.23"
   }
 }

--- a/typescript/packages/common/package.json
+++ b/typescript/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/common",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "tempo common",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/typescript/packages/common/src/hook.test.ts
+++ b/typescript/packages/common/src/hook.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { HookRegistry } from './hook';
+
+describe('HookRegistry', () => {
+	it('should execute request hooks', async () => {
+		type RequestContext = {
+			some: string;
+		};
+		const registry = new HookRegistry<RequestContext, string>('');
+		registry.registerHook('request', async (context, _env, next) => {
+			context.some = 'first';
+			return await next();
+		});
+		registry.registerHook('request', async (context, _env, next) => {
+			context.some += 'second';
+			return await next();
+		});
+		registry.registerHook('request', async (context, _env, next) => {
+			context.some += 'third';
+			return await next();
+		});
+		const context: RequestContext = {
+			some: '',
+		};
+		await registry.executeRequestHooks(context);
+		expect(context.some).toEqual('firstsecondthird');
+	});
+	it('should execute decode hooks', async () => {
+		type DecodeContext = {
+			some: string;
+		};
+		const registry = new HookRegistry<DecodeContext, string>('');
+		registry.registerHook('decode', async (_context, _env, record, next) => {
+			(record as any).data = 'first';
+			return await next();
+		});
+		registry.registerHook('decode', async (_context, _env, record, next) => {
+			(record as any).data += 'second';
+			return await next();
+		});
+		registry.registerHook('decode', async (_context, _env, record, next) => {
+			(record as any).data += 'third';
+			return await next();
+		});
+		const context: DecodeContext = {
+			some: '',
+		};
+		const record = {
+			data: '',
+		};
+		await registry.executeDecodeHooks(context, record);
+		expect(record.data).toEqual('firstsecondthird');
+	});
+	it('should execute response hooks', async () => {
+		type ResponseContext = {
+			some: string;
+		};
+		const registry = new HookRegistry<ResponseContext, string>('');
+		registry.registerHook('response', async (context, _env, next) => {
+			context.some = 'first';
+			return await next();
+		});
+		registry.registerHook('response', async (context, _env, next) => {
+			context.some += 'second';
+			return await next();
+		});
+		registry.registerHook('response', async (context, _env, next) => {
+			context.some += 'third';
+			return await next();
+		});
+		const context: ResponseContext = {
+			some: '',
+		};
+		await registry.executeResponseHooks(context);
+		expect(context.some).toEqual('firstsecondthird');
+	});
+	it('should execute error hooks', async () => {
+		type ErrorContext = {
+			some: string;
+		};
+		const registry = new HookRegistry<ErrorContext, string>('');
+		registry.registerHook('error', async (_context, _env, error, next) => {
+			error.message = 'first';
+			return await next();
+		});
+		registry.registerHook('error', async (_context, _env, error, next) => {
+			error.message += 'second';
+			return await next();
+		});
+		registry.registerHook('error', async (_context, _env, error, next) => {
+			error.message += 'third';
+			return await next();
+		});
+		const context: ErrorContext = {
+			some: '',
+		};
+		const error = new Error();
+		await registry.executeErrorHooks(context, error);
+		expect(error.message).toEqual('firstsecondthird');
+	});
+	it('should shortcircuit hooks', async () => {
+		type RequestContext = {
+			some: string;
+		};
+		const registry = new HookRegistry<RequestContext, string>('');
+		registry.registerHook('request', async (context, _env, next) => {
+			context.some = 'first';
+			return await next();
+		});
+		registry.registerHook('request', async (context) => {
+			context.some += 'second';
+		});
+		registry.registerHook('request', async (context) => {
+			context.some += 'third';
+		});
+		const context: RequestContext = {
+			some: '',
+		};
+		await registry.executeRequestHooks(context);
+		expect(context.some).toEqual('firstsecond');
+	});
+
+	it('should execute all hooks', async () => {
+		type Context = {
+			some: string;
+		};
+		const registry = new HookRegistry<Context, string>('');
+		registry.registerHook('request', async (context, _env, next) => {
+			context.some = 'first';
+			return await next();
+		});
+		registry.registerHook('decode', async (context, _env, _record, next) => {
+			context.some += 'second';
+			return await next();
+		});
+		registry.registerHook('response', async (context, _env, next) => {
+			context.some += 'third';
+			return await next();
+		});
+		registry.registerHook('error', async (context, _env, _error, next) => {
+			context!.some += 'fourth';
+			return await next();
+		});
+
+		const context: Context = {
+			some: '',
+		};
+		const record = {
+			data: '',
+		};
+		const error = new Error();
+		await registry.executeRequestHooks(context);
+		await registry.executeDecodeHooks(context, record);
+		await registry.executeResponseHooks(context);
+		await registry.executeErrorHooks(context, error);
+		expect(context.some).toEqual('firstsecondthirdfourth');
+	});
+});

--- a/typescript/packages/common/src/hook.ts
+++ b/typescript/packages/common/src/hook.ts
@@ -1,0 +1,225 @@
+import { BebopRecord } from 'bebop';
+
+/**
+ * Represents the name of a hook.
+ */
+type HookType = 'request' | 'response' | 'decode' | 'error';
+
+/**
+ * Represents a hook that is executed when a request is sent or received.
+ * @template TContext - The type of the context parameter.
+ * @template TEnvironment - The type of the environment parameter.
+ * @param {TContext} context - The context object.
+ * @param {TEnvironment} environment - The environment object.
+ * @param {RequestHook<TContext, TEnvironment>} next - The next hook in the chain.
+ * @returns {void | Promise<void>} - A void value or a promise resolving to void.
+ */
+type RequestHook<TContext, TEnvironment> = (
+	context: TContext,
+	environment: TEnvironment,
+	next: () => void | Promise<void>,
+) => void | Promise<void>;
+
+/**
+ * Represents a hook that is executed when a response is sent or received.
+ * @template TContext - The type of the context parameter.
+ * @template TEnvironment - The type of the environment parameter.
+ * @param {TContext} context - The context object.
+ * @param {TEnvironment} environment - The environment object.
+ * @param {ResponseHook<TContext, TEnvironment>} next - The next hook in the chain.
+ * @returns {void | Promise<void>} - A void value or a promise resolving to void.
+ */
+type ResponseHook<TContext, TEnvironment> = (
+	context: TContext,
+	environment: TEnvironment,
+	next: () => void | Promise<void>,
+) => void | Promise<void>;
+
+/**
+ * Represents a hook that is executed when a request or response payload is decoded.
+ * @template TContext - The type of the context parameter.
+ * @template TEnvironment - The type of the environment parameter.
+ * @param {TContext} context - The context object.
+ * @param {TEnvironment} environment - The environment object.
+ * @param {BebopRecord} record - The Bebop record being decoded.
+ * @param {DecodeHook<TContext, TEnvironment>} next - The next hook in the chain.
+ * @returns {void | Promise<void>} - A void value or a promise resolving to void.
+ */
+type DecodeHook<TContext, TEnvironment> = (
+	context: TContext,
+	environment: TEnvironment,
+	record: BebopRecord,
+	next: () => void | Promise<void>,
+) => void | Promise<void>;
+
+/**
+ * Represents a hook that is executed when an error occurs.
+ * @template TContext - The type of the context parameter.
+ * @template TEnvironment - The type of the environment parameter.
+ * @param {TContext} context - The context object.
+ * @param {TEnvironment} environment - The environment object.
+ * @param {Error} error - The error that occurred.
+ * @param {ErrorHook<TContext, TEnvironment>} next - The next hook in the chain.
+ * @returns {void | Promise<void>} - A void value or a promise resolving to void.
+ */
+type ErrorHook<TContext, TEnvironment> = (
+	context: TContext | undefined,
+	environment: TEnvironment,
+	error: Error,
+	next: () => void | Promise<void>,
+) => void | Promise<void>;
+
+/**
+ * Represents a hook that can be registered with the `HookRegistry`.
+ */
+type Hook<TContext, TEnvironment> =
+	| RequestHook<TContext, TEnvironment>
+	| ResponseHook<TContext, TEnvironment>
+	| DecodeHook<TContext, TEnvironment>
+	| ErrorHook<TContext, TEnvironment>;
+
+/**
+ * Represents the parameter type for a specific hook type.
+ */
+type HookParam<T extends HookType, TContext, TEnvironment> = T extends 'request'
+	? RequestHook<TContext, TEnvironment>
+	: T extends 'response'
+	? ResponseHook<TContext, TEnvironment>
+	: T extends 'decode'
+	? DecodeHook<TContext, TEnvironment>
+	: T extends 'error'
+	? ErrorHook<TContext, TEnvironment>
+	: never;
+
+/**
+ * Represents a registry for registering and executing different types of hooks.
+ */
+export class HookRegistry<TContext, TEnvironment> {
+	private readonly hooks: Map<HookType, Array<Hook<TContext, TEnvironment>>>;
+	private readonly environment: TEnvironment;
+
+	/**
+	 * Creates an instance of HookRegistry.
+	 * @param {TEnvironment} environment - The environment object to be passed to the hooks.
+	 */
+	constructor(environment: TEnvironment) {
+		this.environment = environment;
+		this.hooks = new Map();
+	}
+
+	/**
+	 * Registers a hook of the specified type.
+	 * @param {HookType} hookType - The type of the hook.
+	 * @param {HookParam} hook - The hook function to register.
+	 */
+	public registerHook<T extends HookType>(hookType: T, hook: HookParam<T, TContext, TEnvironment>): void {
+		const existingHooks = this.hooks.get(hookType) ?? [];
+		existingHooks.push(hook);
+		this.hooks.set(hookType, existingHooks);
+	}
+
+	/**
+	 * Executes registered request hooks.
+	 * @param {TContext} context - The context object to pass to the hooks.
+	 * @returns {Promise<void>}
+	 */
+	public async executeRequestHooks(context: TContext): Promise<void> {
+		await this.executeHooks('request', context);
+	}
+
+	/**
+	 * Executes registered response hooks.
+	 * @param {TContext} context - The context object to pass to the hooks.
+	 * @returns {Promise<void>}
+	 */
+	public async executeResponseHooks(context: TContext): Promise<void> {
+		await this.executeHooks('response', context);
+	}
+
+	/**
+	 * Executes registered decode hooks.
+	 * @param {TContext} context - The context object to pass to the hooks.
+	 * @param {BebopRecord} record - The Bebop record to pass to the decode hooks.
+	 * @returns {Promise<void>}
+	 */
+	public async executeDecodeHooks(context: TContext, record: BebopRecord): Promise<void> {
+		await this.executeHooks('decode', context, record);
+	}
+
+	/**
+	 * Executes registered error hooks.
+	 * @param {TContext} context - The context object to pass to the hooks.
+	 * @param {Error} error - The error object to pass to the error hooks.
+	 * @returns {Promise<void>}
+	 */
+	public async executeErrorHooks(context: TContext | undefined, error: Error): Promise<void> {
+		await this.executeHooks('error', context, undefined, error);
+	}
+
+	/**
+	 * Executes the chain of hooks for the specified hook type.
+	 * @param {HookType} hookType - The type of the hook to execute.
+	 * @param {TContext} context - The context object to pass to the hooks.
+	 * @param {BebopRecord | undefined} record - The Bebop record to pass to the decode hooks (only applicable for 'decode' hook type).
+	 * @param {Error | undefined} error - The error object to pass to the error hooks (only applicable for 'error' hook type).
+	 * @returns {Promise<void>}
+	 */
+	private async executeHooks<T extends HookType>(
+		hookType: T,
+		context: TContext | undefined,
+		record: BebopRecord | undefined = undefined,
+		error: Error | undefined = undefined,
+	): Promise<void> {
+		const hooks = this.hooks.get(hookType);
+		if (hooks === undefined) {
+			return;
+		}
+		const executeNextHook = async (currentIndex: number): Promise<void> => {
+			const currentHook = hooks[currentIndex];
+			if (currentHook !== undefined) {
+				const next = async (): Promise<void> => {
+					await executeNextHook(currentIndex + 1);
+				};
+				if (this.isDecodeHook(hookType, currentHook) && record !== undefined && context !== undefined) {
+					await currentHook(context, this.environment, record, next);
+				} else if (this.isErrorHook(hookType, currentHook) && error !== undefined) {
+					await currentHook(context, this.environment, error, next);
+				} else if (this.isRequestHook(hookType, currentHook) && context !== undefined) {
+					await currentHook(context, this.environment, next);
+				} else if (this.isResponseHook(hookType, currentHook) && context !== undefined) {
+					await currentHook(context, this.environment, next);
+				}
+			}
+		};
+		await executeNextHook(0);
+	}
+
+	// helpers
+	private isDecodeHook(
+		hookType: HookType,
+		_hook: Hook<TContext, TEnvironment>,
+	): _hook is DecodeHook<TContext, TEnvironment> {
+		return hookType === 'decode';
+	}
+
+	private isErrorHook(
+		hookType: HookType,
+		_hook: Hook<TContext, TEnvironment>,
+	): _hook is ErrorHook<TContext, TEnvironment> {
+		return hookType === 'error';
+	}
+
+	private isRequestHook(
+		hookType: HookType,
+		_hook: Hook<TContext, TEnvironment>,
+	): _hook is RequestHook<TContext, TEnvironment> {
+		return hookType === 'request';
+	}
+
+	private isResponseHook(
+		hookType: HookType,
+		_hook: Hook<TContext, TEnvironment>,
+	): _hook is ResponseHook<TContext, TEnvironment> {
+		return hookType === 'response';
+	}
+}

--- a/typescript/packages/common/src/index.ts
+++ b/typescript/packages/common/src/index.ts
@@ -16,6 +16,8 @@ import {
 } from './credentials';
 import { MethodType } from './flags';
 
+import { HookRegistry } from './hook';
+
 export {
 	TempoStatusCode,
 	TempoError,
@@ -35,4 +37,5 @@ export {
 	TempoVersion,
 	tempoStream,
 	MethodType,
+	HookRegistry,
 };

--- a/typescript/packages/common/src/stream.test.ts
+++ b/typescript/packages/common/src/stream.test.ts
@@ -108,9 +108,9 @@ describe('getFlag', () => {
 });
 
 // Mock decoder function
-const mockDecoder = (buffer: Uint8Array): string => {
+const mockDecoder = (buffer: Uint8Array): Promise<string> => {
 	// Convert buffer to string for testing purposes
-	return TempoUtil.textDecoder.decode(buffer);
+	return Promise.resolve(TempoUtil.textDecoder.decode(buffer));
 };
 
 // Helper function to create a ReadableStream with Uint8Array chunks
@@ -289,7 +289,7 @@ describe('TempoStream', () => {
 		const readData: (typeof mockRecord1 | typeof mockRecord2)[] = [];
 
 		for await (const payload of readTempoStream(transformStream.readable, decoder)) {
-			readData.push(payload);
+			readData.push(payload as typeof mockRecord1);
 		}
 
 		// Validate that we read back what we wrote

--- a/typescript/packages/common/src/stream.ts
+++ b/typescript/packages/common/src/stream.ts
@@ -136,13 +136,13 @@ export const getFlag = (flagName: TempoStreamFlag): number => {
  * @generator
  * @template TRecord - The type of the decoded payload.
  * @param {ReadableStream<Uint8Array>} stream - The ReadableStream to read from.
- * @param {(buffer: Uint8Array) => TRecord} decoder - The function to decode the payload.
+ * @param {(buffer: Uint8Array) => Promise<TRecord>} decoder - The function to decode the payload.
  * @yields {TRecord} The decoded payload.
  * @throws {TempoError} If the stream ends in the middle of a Tempo stream frame; this indicates a data loss.
  */
 export async function* readTempoStream<TRecord extends BebopRecord>(
 	stream: ReadableStream<Uint8Array>,
-	decoder: (buffer: Uint8Array) => TRecord,
+	decoder: (buffer: Uint8Array) => Promise<TRecord>,
 	deadline?: Deadline,
 	abortController?: AbortController,
 ): AsyncGenerator<TRecord, void, undefined> {
@@ -207,7 +207,7 @@ export async function* readTempoStream<TRecord extends BebopRecord>(
 							writeIndex += value.length;
 						}
 					}
-					yield decoder(buffer.subarray(readIndex, readIndex + payloadSize));
+					yield await decoder(buffer.subarray(readIndex, readIndex + payloadSize));
 					readIndex += payloadSize;
 				}
 			}

--- a/typescript/packages/common/src/version.ts
+++ b/typescript/packages/common/src/version.ts
@@ -1,1 +1,1 @@
-export const TempoVersion = '0.0.1-alpha.22';
+export const TempoVersion = '0.0.1-alpha.23';

--- a/typescript/packages/node-http/package.json
+++ b/typescript/packages/node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/node-http-router",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "tempo node http",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -19,6 +19,6 @@
     "@types/node": "^14.14.31"
   },
   "dependencies": {
-    "@tempojs/server": "^0.0.1-alpha.22"
+    "@tempojs/server": "^0.0.1-alpha.23"
   }
 }

--- a/typescript/packages/node-http/src/helpers.ts
+++ b/typescript/packages/node-http/src/helpers.ts
@@ -15,7 +15,7 @@ import { Readable, Writable } from 'stream';
  */
 export async function* readTempoStream<TRecord extends BebopRecord>(
 	stream: Readable,
-	decoder: (buffer: Uint8Array) => TRecord,
+	decoder: (buffer: Uint8Array) => Promise<TRecord>,
 	deadline?: Deadline,
 	abortController?: AbortController,
 ): AsyncGenerator<TRecord, void, undefined> {
@@ -65,7 +65,7 @@ export async function* readTempoStream<TRecord extends BebopRecord>(
 					if (writeIndex - readIndex < payloadSize) {
 						break;
 					}
-					yield decoder(buffer.subarray(readIndex, readIndex + payloadSize));
+					yield await decoder(buffer.subarray(readIndex, readIndex + payloadSize));
 					readIndex += payloadSize;
 				}
 			}

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/server",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.23",
   "description": "tempo server",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -16,6 +16,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@tempojs/common": "^0.0.1-alpha.22"
+    "@tempojs/common": "^0.0.1-alpha.23"
   }
 }

--- a/typescript/packages/server/src/router.ts
+++ b/typescript/packages/server/src/router.ts
@@ -1,7 +1,8 @@
 import { TempoError, TempoLogger, TempoStatusCode } from '@tempojs/common';
 import { ServiceRegistry } from './registry';
 import { AuthInterceptor } from './intercept';
-import { Metadata } from '@tempojs/common';
+import { Metadata, HookRegistry } from '@tempojs/common';
+import { ServerContext } from './context';
 
 /**
  * Interface defining the configuration options for a TempoRouter instance.
@@ -67,6 +68,7 @@ export abstract class BaseRouter<TRequest, TEnvironment, TResponse> {
 	protected readonly maxReceiveMessageSize: number;
 	protected readonly maxSendMessageSize?: number;
 	protected readonly maxRetryAttempts: number;
+	protected hooks?: HookRegistry<ServerContext, TEnvironment>;
 
 	/**
 	 * Constructs a new BaseRouter instance.
@@ -155,5 +157,13 @@ export abstract class BaseRouter<TRequest, TEnvironment, TResponse> {
 			return new Metadata();
 		}
 		return Metadata.fromHttpHeader(value);
+	}
+
+	/**
+	 * Defines a hook registry for the router.
+	 * @param hooks - The hook registry to be used.
+	 */
+	public useHooks(hooks: HookRegistry<ServerContext, TEnvironment>): void {
+		this.hooks = hooks;
 	}
 }


### PR DESCRIPTION
Hooks are blocks of independent code that will be executed during certain parts of the application lifecycle; for instance, by registering a 'request' hook on a channel, you can place custom metadata on every outgoing request to set something like a trace ID. On the server, you can define a 'decode' hook on the router that allows you to manipulate a decode record _before_ it is passed to a service method for us.

The same types of hooks can be defined on both the client and server side; just think of them inversely. So where a 'decode' hook on the server lets you inspect and modify an incoming record from a client, on the client the hook it allows you to do the same for a record received from the server.

Each hook has access to the request/response context, but cannot modify things such as HTTP headers. They also have access to an environment object which can be used to pass around reusable components like database clients (this is the same one you provide to a router.)

You also have the ability to short-circuit hook execution by not calling 'next'