### PR TITLE
node: complete the Headers polyfill

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION=0.0.1-alpha.23
+VERSION=0.0.1-alpha.24

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempojs",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "something",
   "private": true,
   "workspaces": [
@@ -26,9 +26,9 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@tempojs/client": "^0.0.1-alpha.23",
-    "@tempojs/common": "^0.0.1-alpha.23",
-    "@tempojs/server": "^0.0.1-alpha.23",
+    "@tempojs/client": "^0.0.1-alpha.24",
+    "@tempojs/common": "^0.0.1-alpha.24",
+    "@tempojs/server": "^0.0.1-alpha.24",
     "bebop": "^2.7.0"
   }
 }

--- a/typescript/packages/cf-router/package.json
+++ b/typescript/packages/cf-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/cloudflare-worker-router",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -19,7 +19,7 @@
   "author": "andrew",
   "license": "",
   "dependencies": {
-    "@tempojs/server": "^0.0.1-alpha.23"
+    "@tempojs/server": "^0.0.1-alpha.24"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20221111.1"

--- a/typescript/packages/client/package.json
+++ b/typescript/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/client",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "xrpc client",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -16,6 +16,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@tempojs/common": "^0.0.1-alpha.23"
+    "@tempojs/common": "^0.0.1-alpha.24"
   }
 }

--- a/typescript/packages/common/package.json
+++ b/typescript/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/common",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "tempo common",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/typescript/packages/common/src/version.ts
+++ b/typescript/packages/common/src/version.ts
@@ -1,1 +1,1 @@
-export const TempoVersion = '0.0.1-alpha.23';
+export const TempoVersion = '0.0.1-alpha.24';

--- a/typescript/packages/node-http/package.json
+++ b/typescript/packages/node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/node-http-router",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "tempo node http",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -19,6 +19,6 @@
     "@types/node": "^14.14.31"
   },
   "dependencies": {
-    "@tempojs/server": "^0.0.1-alpha.23"
+    "@tempojs/server": "^0.0.1-alpha.24"
   }
 }

--- a/typescript/packages/node-http/src/header.test.ts
+++ b/typescript/packages/node-http/src/header.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'vitest';
+import { FetchHeadersAdapter } from './header';
+
+describe('FetchHeadersAdapter', () => {
+	it('should retrieve header value using get()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json' });
+		const value = adapter.get('Content-Type');
+		return value === 'application/json';
+	});
+
+	it('should check if header exists using has()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json' });
+		const exists = adapter.has('Content-Type');
+		return exists;
+	});
+
+	it('should iterate over each header using forEach()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json', Authorization: 'Bearer token' });
+		let count = 0;
+		adapter.forEach((_value, _name) => {
+			count++;
+		});
+		return count === 2;
+	});
+
+	it('should iterate over header names using keys()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json', Authorization: 'Bearer token' });
+		const keys = Array.from(adapter.keys());
+		return keys.length === 2 && keys.includes('content-type') && keys.includes('authorization');
+	});
+
+	it('should iterate over header values using values()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json', Authorization: 'Bearer token' });
+		const values = Array.from(adapter.values());
+		return values.length === 2 && values.includes('application/json') && values.includes('Bearer token');
+	});
+
+	it('should iterate over header entries using entries()', () => {
+		const adapter = new FetchHeadersAdapter({ 'Content-Type': 'application/json', Authorization: 'Bearer token' });
+		const entries = Array.from(adapter.entries());
+		return (
+			entries.length === 2 &&
+			entries.some(([name, value]) => name === 'content-type' && value === 'application/json') &&
+			entries.some(([name, value]) => name === 'authorization' && value === 'Bearer token')
+		);
+	});
+});

--- a/typescript/packages/node-http/src/header.ts
+++ b/typescript/packages/node-http/src/header.ts
@@ -7,8 +7,12 @@ import { IncomingHttpHeaders } from 'http';
  * @interface IFetchHeaders
  */
 interface IFetchHeaders {
-	get(name: string): string | null;
+	get(name: string): string | undefined;
 	has(name: string): boolean;
+	forEach(callback: (value: string, name: string) => void): void;
+	keys(): IterableIterator<string>;
+	values(): IterableIterator<string>;
+	entries(): IterableIterator<[string, string]>;
 }
 
 /**
@@ -20,7 +24,7 @@ interface IFetchHeaders {
  * @implements {IFetchHeaders}
  */
 export class FetchHeadersAdapter implements IFetchHeaders {
-	private headers: Map<string, string>;
+	private readonly headers: Map<string, string>;
 
 	/**
 	 * Creates an instance of FetchHeadersAdapter.
@@ -38,15 +42,14 @@ export class FetchHeadersAdapter implements IFetchHeaders {
 	}
 
 	/**
-	 * Retrieves the header value associated with the provided header name.
+	 * Retrieves the first header value associated with the provided header name.
 	 *
 	 * @param {string} name - The name of the header to retrieve.
-	 * @returns {string | null} The value of the header, or null if it is not found.
+	 * @returns {string | undefined} The value of the header, or undefined if it is not found.
 	 * @memberof FetchHeadersAdapter
 	 */
-	get(name: string): string | null {
-		const value = this.headers.get(name.toLowerCase());
-		return value !== undefined ? value : null;
+	get(name: string): string | undefined {
+		return this.headers.get(name.toLowerCase());
 	}
 
 	/**
@@ -58,5 +61,45 @@ export class FetchHeadersAdapter implements IFetchHeaders {
 	 */
 	has(name: string): boolean {
 		return this.headers.has(name.toLowerCase());
+	}
+
+	/**
+	 * Executes the provided callback function for each header.
+	 *
+	 * @param {(value: string, name: string) => void} callback - The callback function to execute for each header.
+	 * @memberof FetchHeadersAdapter
+	 */
+	forEach(callback: (value: string, name: string) => void): void {
+		this.headers.forEach(callback);
+	}
+
+	/**
+	 * Returns an iterator that contains the names (keys) of all headers.
+	 *
+	 * @returns {IterableIterator<string>} An iterator for the names (keys) of all headers.
+	 * @memberof FetchHeadersAdapter
+	 */
+	*keys(): IterableIterator<string> {
+		yield* this.headers.keys();
+	}
+
+	/**
+	 * Returns an iterator that contains the values of all headers.
+	 *
+	 * @returns {IterableIterator<string>} An iterator for the values of all headers.
+	 * @memberof FetchHeadersAdapter
+	 */
+	*values(): IterableIterator<string> {
+		yield* this.headers.values();
+	}
+
+	/**
+	 * Returns an iterator that contains all key/value pairs of the headers.
+	 *
+	 * @returns {IterableIterator<[string, string]>} An iterator for all key/value pairs of the headers.
+	 * @memberof FetchHeadersAdapter
+	 */
+	*entries(): IterableIterator<[string, string]> {
+		yield* this.headers.entries();
 	}
 }

--- a/typescript/packages/server/package.json
+++ b/typescript/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tempojs/server",
-  "version": "0.0.1-alpha.23",
+  "version": "0.0.1-alpha.24",
   "description": "tempo server",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -16,6 +16,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@tempojs/common": "^0.0.1-alpha.23"
+    "@tempojs/common": "^0.0.1-alpha.24"
   }
 }


### PR DESCRIPTION
Adds all the missing methods to our HeaderAdapter in the node router, so now it can be used for all the different ways one might want to read it.