### PR TITLE
fix(metadata): metadata loss / bin-keys

### DIFF
--- a/typescript/packages/cf-router/src/router.ts
+++ b/typescript/packages/cf-router/src/router.ts
@@ -281,7 +281,7 @@ export class TempoRouter<TEnv> extends BaseRouter<Request, TEnv, Response> {
 				);
 			}
 			const metadata = this.getCustomMetaData(request.headers.get('custom-metadata'));
-			const previousAttempts = metadata.get('tempo-previous-rpc-attempts');
+			const previousAttempts = metadata.getTextValues('tempo-previous-rpc-attempts');
 			if (previousAttempts !== undefined && previousAttempts[0] !== undefined) {
 				const numberOfAttempts = TempoUtil.tryParseInt(previousAttempts[0]);
 				if (numberOfAttempts > this.maxRetryAttempts) {

--- a/typescript/packages/common/src/base64.test.ts
+++ b/typescript/packages/common/src/base64.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { Base64 } from './base64';
+
+describe('Base64', () => {
+	it('should correctly encode data', () => {
+		const testData = new Uint8Array([84, 101, 115, 116]); // ASCII for 'Test'
+		const expectedResult = 'VGVzdA==';
+
+		expect(Base64.encode(testData)).toBe(expectedResult);
+	});
+
+	it('should correctly decode data', () => {
+		const testData = 'VGVzdA==';
+		const expectedResult = new Uint8Array([84, 101, 115, 116]);
+
+		expect(Base64.decode(testData)).toEqual(expectedResult);
+	});
+
+	it('should correctly handle data with padding', () => {
+		const testData = new Uint8Array([84, 101, 115]); // ASCII for 'Tes'
+		const expectedResult = 'VGVz';
+
+		expect(Base64.encode(testData)).toBe(expectedResult);
+	});
+
+	it('should correctly handle data without padding', () => {
+		const testData = 'VGVz';
+		const expectedResult = new Uint8Array([84, 101, 115]);
+
+		expect(Base64.decode(testData)).toEqual(expectedResult);
+	});
+
+	it('should handle round trip encoding and decoding', () => {
+		const testData = new Uint8Array([84, 101, 115, 116, 97, 98, 99, 100]); // ASCII for 'Testabcd'
+
+		expect(Base64.decode(Base64.encode(testData))).toEqual(testData);
+	});
+});
+
+describe('Base64 Fuzzing', () => {
+	it('should correctly handle random data', () => {
+		// Run the test 100 times
+		for (let i = 0; i < 100; i++) {
+			// Generate a Uint8Array of random length (up to 256) with random values
+			const randomLength = Math.floor(Math.random() * 256);
+			const randomData = new Uint8Array(randomLength);
+			for (let j = 0; j < randomLength; j++) {
+				randomData[j] = Math.floor(Math.random() * 256);
+			}
+			// Encode and decode the random data and expect to get back the same data
+			const roundTripData = Base64.decode(Base64.encode(randomData));
+			expect(roundTripData).toEqual(randomData);
+		}
+	});
+});

--- a/typescript/packages/common/src/base64.ts
+++ b/typescript/packages/common/src/base64.ts
@@ -71,7 +71,7 @@ const decode = (input: string): Uint8Array => {
 	// Byte index counter for the output array.
 	let byteIndex = 0;
 
-	// Iterate over the base64 characters in the input, four at a time. 
+	// Iterate over the base64 characters in the input, four at a time.
 	for (; i < baseLength; i += 4) {
 		// Decode four base64 characters into a 24-bit number. The `lookup` array maps ASCII character codes to their base64 values.
 		tmp =

--- a/typescript/packages/common/src/base64.ts
+++ b/typescript/packages/common/src/base64.ts
@@ -1,0 +1,114 @@
+// prettier-ignore
+const base64Table = [
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+];
+// prettier-ignore
+const lookup = new Uint8Array([
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 62, 0, 62, 0, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+	9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 63, 0, 26, 27, 28, 29, 30, 31, 32, 33,
+	34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+]);
+
+/**
+ * Encodes a given Uint8Array into a Base64 string.
+ *
+ * @param input The Uint8Array to encode.
+ * @returns The Base64-encoded string.
+ */
+const encode = (input: Uint8Array): string => {
+	// Initialize an empty string to build the output Base64-encoded string.
+	let output = '';
+	// Initialize a variable to count how many padding characters ('=') we'll need to add to the end of the encoded string.
+	let padding = 0;
+
+	// Loop over each byte in the input array, incrementing by 3 each time. Base64 encoding works on 3 bytes at a time.
+	for (let i = 0; i < input.length; i += 3) {
+		// Combine three bytes into a single 24-bit number. Shifts each byte to its correct position in the combined value.
+		// If the byte is not present (beyond the length of the input), NaN will be returned.
+		const combined = (input[i]! << 16) | (input[i + 1]! << 8) | input[i + 2]!;
+
+		// If the second byte is not present, increment the padding counter.
+		if (isNaN(input[i + 1]!)) padding++;
+		// If the third byte is not present, increment the padding counter.
+		if (isNaN(input[i + 2]!)) padding++;
+
+		// Add the Base64 encoding of the 24-bit number to the output string. The 24-bit number is divided into four 6-bit numbers.
+		// Each 6-bit number is used as an index into the Base64 table to get the corresponding character.
+		output +=
+			base64Table[(combined >> 18) & 63]! +
+			base64Table[(combined >> 12) & 63]! +
+			base64Table[(combined >> 6) & 63] +
+			base64Table[combined & 63];
+	}
+	// Return the output string, but remove as many characters from the end as there are padding characters needed, then add the appropriate number of '=' characters.
+	// If two padding characters are needed, add '=='. If one is needed, add '='. If none are needed, add nothing.
+	return output.slice(0, output.length - padding) + (padding === 2 ? '==' : padding === 1 ? '=' : '');
+};
+
+/**
+ * Decodes a given Base64 string into a Uint8Array.
+ * @param input The Base64 string to decode.
+ * @returns The decoded Uint8Array.
+ */
+const decode = (input: string): Uint8Array => {
+	// Length of the input string.
+	const sourceLength = input.length;
+	// Determine the number of padding characters in the input by checking the last two characters.
+	const paddingLength = input[sourceLength - 2] === '=' ? 2 : input[sourceLength - 1] === '=' ? 1 : 0;
+	// Determine the length of the input that contains the base64 characters, excluding padding.
+	const baseLength = (sourceLength - paddingLength) & 0xfffffffc;
+	// Initialize a Uint8Array to hold the decoded output.
+	const output = new Uint8Array((sourceLength / 4) * 3 - paddingLength);
+	// Temporary variable for intermediate computations.
+	let tmp;
+	// Iteration variable for the main loop.
+	let i = 0;
+	// Byte index counter for the output array.
+	let byteIndex = 0;
+
+	// Iterate over the base64 characters in the input, four at a time. 
+	for (; i < baseLength; i += 4) {
+		// Decode four base64 characters into a 24-bit number. The `lookup` array maps ASCII character codes to their base64 values.
+		tmp =
+			(lookup[input.charCodeAt(i)]! << 18) |
+			(lookup[input.charCodeAt(i + 1)]! << 12) |
+			(lookup[input.charCodeAt(i + 2)]! << 6) |
+			lookup[input.charCodeAt(i + 3)]!;
+		// Split the 24-bit number into three 8-bit bytes and add them to the output.
+		output[byteIndex++] = (tmp >> 16) & 0xff;
+		output[byteIndex++] = (tmp >> 8) & 0xff;
+		output[byteIndex++] = tmp & 0xff;
+	}
+
+	// If there's one padding character, decode the remaining two base64 characters into two bytes.
+	if (paddingLength === 1) {
+		tmp =
+			(lookup[input.charCodeAt(i)]! << 10) |
+			(lookup[input.charCodeAt(i + 1)]! << 4) |
+			(lookup[input.charCodeAt(i + 2)]! >> 2);
+		output[byteIndex++] = (tmp >> 8) & 0xff;
+		output[byteIndex++] = tmp & 0xff;
+	}
+
+	// If there's two padding characters, decode the remaining base64 character into one byte.
+	if (paddingLength === 2) {
+		tmp = (lookup[input.charCodeAt(i)]! << 2) | (lookup[input.charCodeAt(i + 1)]! >> 4);
+		output[byteIndex++] = tmp & 0xff;
+	}
+
+	// Return the output array.
+	return output;
+};
+
+/**
+ * A collection of Base64 encoding and decoding functions.
+ */
+export const Base64 = {
+	encode,
+	decode,
+};

--- a/typescript/packages/common/src/index.ts
+++ b/typescript/packages/common/src/index.ts
@@ -17,6 +17,7 @@ import {
 import { MethodType } from './flags';
 
 import { HookRegistry } from './hook';
+import { Base64 } from './base64';
 
 export {
 	TempoStatusCode,
@@ -38,4 +39,5 @@ export {
 	tempoStream,
 	MethodType,
 	HookRegistry,
+	Base64,
 };

--- a/typescript/packages/common/src/metadata.test.ts
+++ b/typescript/packages/common/src/metadata.test.ts
@@ -18,19 +18,21 @@ describe('Metadata', () => {
 
 	it('sets and gets binary values', () => {
 		const metadata = new Metadata();
-		const binaryValue1 = new TextEncoder().encode('value1');
-		const binaryValue2 = new TextEncoder().encode('value2');
+		const value1 = 'value1';
+		const value2 = 'value2';
+		const binaryValue1 = new TextEncoder().encode(value1);
+		const binaryValue2 = new TextEncoder().encode(value2);
 
 		metadata.set('key1-bin', binaryValue1);
 		metadata.set('Key2-bin', binaryValue2);
 
-		const valuesForKey1 = metadata.get('key1-bin');
-		const valuesForKey2 = metadata.get('Key2-bin');
+		const valuesForKey1 = metadata.get('key1-bin') as Uint8Array[];
+		const valuesForKey2 = metadata.get('Key2-bin') as Uint8Array[];
 
 		expect(valuesForKey1).toBeTruthy();
 		expect(valuesForKey2).toBeTruthy();
-		expect(new TextEncoder().encode(valuesForKey1![0]).toString()).toBe(binaryValue1.toString());
-		expect(new TextEncoder().encode(valuesForKey2![0]).toString()).toBe(binaryValue2.toString());
+		expect(new TextDecoder().decode(valuesForKey1![0])).toEqual(value1);
+		expect(new TextDecoder().decode(valuesForKey2![0])).toEqual(value2);
 	});
 
 	it('appends values', () => {
@@ -113,11 +115,11 @@ describe('Metadata', () => {
 		const httpHeader = metadata.toHttpHeader();
 		const metadataFromHeader = Metadata.fromHttpHeader(httpHeader);
 
-		const valuesForKey = metadataFromHeader.get(key);
+		const valuesForKey = metadataFromHeader.get(key) as Uint8Array[];
 
 		expect(valuesForKey).toBeTruthy();
 		expect(valuesForKey![0]).toBeDefined();
-		expect(valuesForKey![0]).toEqual(new TextDecoder().decode(value));
+		expect(new TextDecoder().decode(valuesForKey![0])).toStrictEqual(new TextDecoder().decode(value));
 	});
 
 	it('toHttpHeader and fromHttpHeader test with binary data', () => {
@@ -133,14 +135,14 @@ describe('Metadata', () => {
 		const httpHeader = metadata.toHttpHeader();
 		const metadataFromHeader = Metadata.fromHttpHeader(httpHeader);
 
-		const valuesForKey1 = metadataFromHeader.get(key1);
-		const valuesForKey2 = metadataFromHeader.get(key2);
+		const valuesForKey1 = metadataFromHeader.get(key1) as string[];
+		const valuesForKey2 = metadataFromHeader.get(key2) as Uint8Array[];
 
 		expect(valuesForKey1).toBeTruthy();
-		expect(valuesForKey1![0]).toBe(value1);
+		expect(valuesForKey1![0]).toStrictEqual(value1);
 
 		expect(valuesForKey2).toBeTruthy();
-		expect(valuesForKey2![0]).toEqual(new TextDecoder().decode(value2));
+		expect(new TextDecoder().decode(valuesForKey2![0])).toStrictEqual(new TextDecoder().decode(value2));
 	});
 
 	it('fuzzing test for toHttpHeader', () => {

--- a/typescript/packages/common/src/metadata.ts
+++ b/typescript/packages/common/src/metadata.ts
@@ -126,7 +126,7 @@ export class Metadata {
 	append(key: string, value: string | Uint8Array): void {
 		if (this.isFrozen) throw new Error('Attempted to append metadata on a frozen collection.');
 		if (!Metadata.isValidKey(key)) throw new Error(`Invalid metadata key: '${key}'`);
-		
+
 		key = key.toLowerCase();
 		const isBinaryValue = value instanceof Uint8Array;
 		const isBinaryKey = Metadata.isBinaryKey(key);
@@ -141,7 +141,7 @@ export class Metadata {
 		}
 
 		const existingValues = this.data.get(key) || [];
-		
+
 		existingValues.push(value as string);
 		this.data.set(key, existingValues);
 	}

--- a/typescript/packages/common/src/metadata.ts
+++ b/typescript/packages/common/src/metadata.ts
@@ -150,6 +150,7 @@ export class Metadata {
 	 * Retrieves the values for a metadata entry with the given key.
 	 * @param key The metadata key. It will be converted to lowercase.
 	 * @returns An array of metadata values or undefined if the key does not exist.
+	 * @deprecated Use getBinaryValues or getTextValues instead.
 	 */
 	get(key: string): string[] | Uint8Array[] | undefined {
 		key = key.toLowerCase();
@@ -162,6 +163,27 @@ export class Metadata {
 		} else {
 			return values;
 		}
+	}
+
+	/**
+	 * Retrieves the binary values for a metadata entry with the given key.
+	 * @param key The metadata key. Case-insensitive.
+	 * @returns An array of binary metadata values or undefined if the key does not exist.
+	 */
+	getBinaryValues(key: string): Uint8Array[] | undefined {
+		if (!Metadata.isBinaryKey(key)) throw new Error('Attempted to get binary values with a text key');
+		key = key.toLowerCase();
+		return this.data.get(key)?.map((value) => Metadata.base64Decode(value));
+	}
+	/**
+	 * Retrieves the text values for a metadata entry with the given key.
+	 * @param key The metadata key. Case-insensitive.
+	 * @returns An array of text metadata values or undefined if the key does not exist.
+	 */
+	getTextValues(key: string): string[] | undefined {
+		if (Metadata.isBinaryKey(key)) throw new Error('Attempted to get text values with a binary key');
+		key = key.toLowerCase();
+		return this.data.get(key);
 	}
 
 	/**

--- a/typescript/packages/common/src/metadata.ts
+++ b/typescript/packages/common/src/metadata.ts
@@ -1,3 +1,4 @@
+import { Base64 } from './base64';
 import { TempoUtil } from './utils';
 
 /**
@@ -55,7 +56,6 @@ export class Metadata {
 	 */
 	private static isValidMetadataTextValue(textValue: string): boolean {
 		// Must be a valid Tempo "ASCII-Value" as defined here:
-		//   TODO
 		// This means printable ASCII (including/plus spaces); 0x20 to 0x7E inclusive.
 		const bytes = TempoUtil.textEncoder.encode(textValue); // Tempo validates strings on the byte level, not Unicode.
 		for (const ch of bytes) {
@@ -80,12 +80,8 @@ export class Metadata {
 	 * @param value The input string.
 	 * @returns The base64-encoded string.
 	 */
-	private static base64Encode(value: string | ArrayBuffer): string {
-		if (typeof value === 'string') {
-			value = TempoUtil.textEncoder.encode(value);
-		}
-		const binaryString = String.fromCharCode(...new Uint8Array(value));
-		return btoa(binaryString);
+	private static base64Encode(value: Uint8Array): string {
+		return Base64.encode(value);
 	}
 
 	/**
@@ -93,15 +89,8 @@ export class Metadata {
 	 * @param value The base64-encoded input string.
 	 * @returns The decoded string.
 	 */
-	private static base64Decode(value: string): ArrayBuffer {
-		const binaryString = atob(value);
-		const byteArray = new Uint8Array(binaryString.length);
-
-		for (let i = 0; i < binaryString.length; i++) {
-			byteArray[i] = binaryString.charCodeAt(i);
-		}
-
-		return byteArray.buffer;
+	private static base64Decode(value: string): Uint8Array {
+		return Base64.decode(value);
 	}
 
 	/**
@@ -110,30 +99,22 @@ export class Metadata {
 	 * @param key The metadata key. It will be converted to lowercase.
 	 * @param value The metadata value, can be a string or ArrayBuffer.
 	 */
-	set(key: string, value: string | ArrayBuffer): void {
-		if (this.isFrozen) {
-			throw new Error('Attempted to set metadata on a frozen collection.');
-		}
-		if (!Metadata.isValidKey(key)) {
-			throw new Error(`Invalid metadata key: '${key}'`);
-		}
+	set(key: string, value: string | Uint8Array): void {
+		if (this.isFrozen) throw new Error('Attempted to set metadata on a frozen collection.');
+		if (!Metadata.isValidKey(key)) throw new Error(`Invalid metadata key: '${key}'`);
 		key = key.toLowerCase();
 
+		const isBinaryValue = value instanceof Uint8Array;
 		const isBinaryKey = Metadata.isBinaryKey(key);
-		if (!isBinaryKey && value instanceof ArrayBuffer) {
-			throw new Error('Attempted to set binary value without a valid binary key');
-		}
-		if (isBinaryKey) {
-			value = Metadata.base64Encode(value);
-		} else if (typeof value !== 'string') {
-			value = TempoUtil.textDecoder.decode(value);
-		}
+		if (!isBinaryKey && isBinaryValue) throw new Error('Attempted to set binary value without a valid binary key');
+		if (isBinaryKey && !isBinaryValue) throw new Error('Attempted to set text value with a binary key');
 
-		if (!Metadata.isValidMetadataTextValue(value)) {
+		if (isBinaryKey && isBinaryValue) value = Metadata.base64Encode(value as Uint8Array);
+
+		if (!Metadata.isValidMetadataTextValue(value as string)) {
 			throw new Error('invalid metadata value: not ASCII');
 		}
-
-		this.data.set(key, [value]);
+		this.data.set(key, [value as string]);
 	}
 
 	/**
@@ -142,32 +123,26 @@ export class Metadata {
 	 * @param key The metadata key. It will be converted to lowercase.
 	 * @param value The metadata value, can be a string or ArrayBuffer.
 	 */
-	append(key: string, value: string | ArrayBuffer): void {
-		if (this.isFrozen) {
-			throw new Error('Attempted to append metadata on a frozen collection.');
-		}
-		if (!Metadata.isValidKey(key)) {
-			throw new Error(`Invalid metadata key: '${key}'`);
-		}
-
+	append(key: string, value: string | Uint8Array): void {
+		if (this.isFrozen) throw new Error('Attempted to append metadata on a frozen collection.');
+		if (!Metadata.isValidKey(key)) throw new Error(`Invalid metadata key: '${key}'`);
+		
 		key = key.toLowerCase();
+		const isBinaryValue = value instanceof Uint8Array;
 		const isBinaryKey = Metadata.isBinaryKey(key);
-		if (!isBinaryKey && value instanceof ArrayBuffer) {
-			throw new Error('Attempted to set binary value without a valid binary key');
-		}
 
-		if (isBinaryKey) {
-			value = Metadata.base64Encode(value);
-		} else if (typeof value !== 'string') {
-			value = TempoUtil.textDecoder.decode(value);
-		}
+		if (!isBinaryKey && isBinaryValue) throw new Error('Attempted to set binary value without a valid binary key');
+		if (isBinaryKey && !isBinaryValue) throw new Error('Attempted to set text value with a binary key');
 
-		if (!Metadata.isValidMetadataTextValue(value)) {
+		if (isBinaryKey && isBinaryValue) value = Metadata.base64Encode(value as Uint8Array);
+
+		if (!Metadata.isValidMetadataTextValue(value as string)) {
 			throw new Error('invalid metadata value: not ASCII');
 		}
 
 		const existingValues = this.data.get(key) || [];
-		existingValues.push(value);
+		
+		existingValues.push(value as string);
 		this.data.set(key, existingValues);
 	}
 
@@ -176,16 +151,14 @@ export class Metadata {
 	 * @param key The metadata key. It will be converted to lowercase.
 	 * @returns An array of metadata values or undefined if the key does not exist.
 	 */
-	get(key: string): string[] | undefined {
+	get(key: string): string[] | Uint8Array[] | undefined {
 		key = key.toLowerCase();
-
 		const values = this.data.get(key);
 		if (!values) {
 			return undefined;
 		}
-
 		if (Metadata.isBinaryKey(key)) {
-			return values.map((value) => TempoUtil.textDecoder.decode(Metadata.base64Decode(value)));
+			return values.map((value) => Metadata.base64Decode(value));
 		} else {
 			return values;
 		}
@@ -254,21 +227,12 @@ export class Metadata {
 	 * @param otherMetadata The other Metadata instance to merge.
 	 */
 	concat(otherMetadata: Metadata): void {
-		if (this.isFrozen) {
-			throw new Error('Attempted to concat metadata into a frozen collection.');
-		}
-
+		if (this.isFrozen) throw new Error('Attempted to concat metadata into a frozen collection.');
 		for (const key of otherMetadata.keys()) {
 			const otherValues = otherMetadata.get(key);
 			if (otherValues) {
-				if (this.data.has(key)) {
-					for (const value of otherValues) {
-						this.append(key, value);
-					}
-				} else {
-					for (const value of otherValues) {
-						this.set(key, value);
-					}
+				for (const value of otherValues) {
+					this.append(key, value);
 				}
 			}
 		}

--- a/typescript/packages/node-http/src/router.ts
+++ b/typescript/packages/node-http/src/router.ts
@@ -275,7 +275,7 @@ export class TempoRouter<TEnv> extends BaseRouter<IncomingMessage, TEnv, ServerR
 			const metadata =
 				metadataHeader && typeof metadataHeader === 'string' ? this.getCustomMetaData(metadataHeader) : new Metadata();
 
-			const previousAttempts = metadata.get('tempo-previous-rpc-attempts');
+			const previousAttempts = metadata.getTextValues('tempo-previous-rpc-attempts');
 			if (previousAttempts !== undefined && previousAttempts[0] !== undefined) {
 				const numberOfAttempts = TempoUtil.tryParseInt(previousAttempts[0]);
 				if (numberOfAttempts > this.maxRetryAttempts) {


### PR DESCRIPTION
This change refactors metadata to fix some subtle bugs where data was overwritten when it should have been appended. It also adds improved base64 encoding/decoding, and correctly maps binary data back to a buffer when you use 'get' rather than dubiously trying to decode it as UTF8